### PR TITLE
fix: dropdown z-index 설정 및 배경 색 추가

### DIFF
--- a/src/components/common/Dropdown/DropdownStyle.js
+++ b/src/components/common/Dropdown/DropdownStyle.js
@@ -39,10 +39,12 @@ const Options = styled.li`
   position: absolute;
   top: 58px;
   left: 0px;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   padding: 10px 0;
   width: 100%;
+  background-color: var(--white);
   border: 1px solid var(--gray-300);
   border-radius: 8px;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## 작업 내용

- 배경색을 white로 지정하였습니다.
- z-index를 지정하여 dropdown을 눌러도 요소가 겹치지 않게 수정하였습니다.

### 스크린샷 (선택)
<img width="653" height="377" alt="image" src="https://github.com/user-attachments/assets/e09cad98-b1e6-464c-ae45-e0c60211d340" />
