### PR TITLE
refactor: CardModal 컴포넌트 기능 변경 및 디자인 일부 수정

### DIFF
--- a/src/components/CardModal/CardModal.jsx
+++ b/src/components/CardModal/CardModal.jsx
@@ -4,6 +4,7 @@ import Avatar from "../common/Avatar/Avatar";
 import { Button } from "../common/Button/Button";
 import RelationshipBadge from "../common/RelationshipBadge/RelationshipBadge";
 import * as S from "./CardModalStyle";
+import ReactQuill from "react-quill-new";
 
 /**
  * @param {string} name 작성자 이름
@@ -39,7 +40,15 @@ const CardModal = ({
           </S.Left>
           <S.Date>{createdDate}</S.Date>
         </S.Header>
-        <S.Content>{content}</S.Content>
+        <ReactQuill
+          value={content}
+          readOnly
+          theme="snow"
+          modules={{
+            toolbar: false,
+          }}
+          style={{ height: "240px", overflowY: "auto" }}
+        />
         <S.Footer>
           <Button
             style={{ width: "120px" }}

--- a/src/components/CardModal/CardModalStyle.js
+++ b/src/components/CardModal/CardModalStyle.js
@@ -8,7 +8,6 @@ export const Layout = styled.div`
   padding: 40px;
   font-family: ${({ $fonts }) => $fonts};
   width: 600px;
-  height: 476px;
 `;
 
 export const Header = styled.div`
@@ -41,17 +40,11 @@ export const Date = styled.div`
   align-content: center;
 `;
 
-// 다른 브라우저에서 테스트 필요
-export const Content = styled.div`
-  font: var(--font-18-regular);
-  overflow-y: auto;
-  padding-right: 16px;
-`;
-
 export const Footer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: auto;
 `;
 export const WideButton = styled(Button)`
   width: 300px;

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -8,12 +8,13 @@ import ModalContext from "../contexts/ModalContext";
  */
 const useModal = () => {
   const modalContext = useContext(ModalContext);
+  const { isOpen, openModal, closeModal } = modalContext;
 
   if (!modalContext) {
     throw new Error("Modal Context를 찾을 수 없습니다");
   }
 
-  return modalContext;
+  return { isOpen, openModal, closeModal };
 };
 
 export default useModal;

--- a/src/pages/Test/APITest.jsx
+++ b/src/pages/Test/APITest.jsx
@@ -20,10 +20,15 @@ import {
   getRollingPaperList,
 } from "../../lib/api/rollingPaper";
 import CardList from "../../components/CardList/CardList";
+import useModal from "../../hooks/useModal";
+import CardModal from "../../components/CardModal/CardModal";
+import Textarea from "../../components/common/Textarea/Textarea";
 
 const APITest = () => {
   const [datas, setDatas] = useState([]);
   const [rpDatas, setRpDatas] = useState([]);
+  const [content, setContent] = useState("");
+  const { openModal, closeModal } = useModal();
 
   // const TeamId = "23-2";
   const RecipientId = 16771;
@@ -39,6 +44,23 @@ const APITest = () => {
       font: FONTS[1].value, // 배열의 2번째 원소 => "Pretendard"
     });
     console.log(datas);
+  };
+
+  const handleContentChange = (value) => {
+    setContent(value);
+  };
+
+  const handleOpenModalClick = () => {
+    openModal(
+      <CardModal
+        name="asdf"
+        profileImg="https://fastly.picsum.photos/id/794/200/200.jpg?hmac=qNLJvkiBmg4TyCSCwU__daf9sb5La0_1eRzJewRgIyU"
+        content={content}
+        createdDate={formatDate(new Date())}
+        relationship="친구"
+        onCloseModal={closeModal}
+      />,
+    );
   };
 
   const handleGetListClick = async () => {
@@ -142,6 +164,7 @@ const APITest = () => {
         <button onClick={() => handleDeleteRollingPaperClick()}>
           롤링 페이퍼 삭제
         </button>
+        <button onClick={handleOpenModalClick}>모달 열기</button>
       </div>
       <div style={{ display: "flex", overflowX: "auto", gap: "1rem" }}>
         {rpDatas?.map((data) => (
@@ -154,6 +177,7 @@ const APITest = () => {
           />
         ))}
       </div>
+      <Textarea value={content} onChange={handleContentChange} />
     </div>
   );
 };


### PR DESCRIPTION
## 연관된 이슈
close #51 

## 작업 내용
- 확인 버튼 하단에 고정
- content를 quill을 이용해 서식이 적용된 텍스트로 보이게 설정

### 스크린샷 (선택)
<img width="455" height="344" alt="{BDC1BCEB-F070-4C1B-813F-88819D6621DF}" src="https://github.com/user-attachments/assets/0f82e30d-bb06-4a4d-acb8-ec7cc1f06d5b" />
<img width="455" height="344" alt="{F253DF57-9D0C-401B-8464-7386F081300A}" src="https://github.com/user-attachments/assets/3fe4c6c1-b82f-4ba1-bd26-fa4ff57cd9b1" />

## 리뷰 요구 사항
- 현재 사양에는 콘텐츠 라인에 border가 없지만 구현 사항에는 있습니다.
  - 이 부분을 없애는 것이 낫다고 보시나요?
